### PR TITLE
Support deck tags

### DIFF
--- a/src/app/decks/home/DeckHome.js
+++ b/src/app/decks/home/DeckHome.js
@@ -197,6 +197,12 @@ class DeckHome extends Component {
                   {isLoading ? <span className="text-secondary">Loading info...</span> : deck.title}
                 </h1>
                 {deck.description && <p className="text-dark h5 mb-1">{deck.description}</p>}
+                {deck.tags &&
+                  deck.tags.map(tag => (
+                    <Label key={tag._id} className="mb-2">
+                      {tag.value}
+                    </Label>
+                  ))}
               </div>
               <p
                 className="text-secondary text-uppercase m-0 mt-4 mb-2"

--- a/src/app/decks/new/DeckNew.js
+++ b/src/app/decks/new/DeckNew.js
@@ -28,12 +28,18 @@ class DeckNew extends Component {
   onAddTag = (e, { value }) => {
     this.createTag(value).then(tag => {
       const option = { text: tag.value, value: tag._id };
-      this.setState({ options: [option, ...this.state.options] });
+      this.setState({
+        options: [option, ...this.state.options],
+        selectedTags: [...this.state.selectedTags, tag._id],
+      });
     });
   };
 
-  onChangeTag = (e, { value }) => {
-    this.setState({ selectedTags: value });
+  onChangeTag = (e, data) => {
+    const { value } = data;
+    const { options } = this.state;
+    const tags = value.filter(el => options.find(tag => tag.value === el));
+    this.setState({ selectedTags: tags });
   };
 
   fetchTags = () => {
@@ -51,9 +57,7 @@ class DeckNew extends Component {
   };
 
   createTag = value => {
-    return tagApi.createTag(value).then(({ data }) => {
-      return data;
-    });
+    return tagApi.createTag(value).then(({ data }) => data);
   };
 
   render() {

--- a/src/app/decks/new/DeckNew.js
+++ b/src/app/decks/new/DeckNew.js
@@ -1,16 +1,23 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Button, Form, Input, TextArea, Segment } from "semantic-ui-react";
+import { Button, Form, Input, TextArea, Segment, Dropdown } from "semantic-ui-react";
 
 import withErrors from "../../../helpers/withErrors";
 
 import * as api from "../deckActions";
+import * as tagApi from "../tagActions";
 
 class DeckNew extends Component {
   state = {
     title: "",
     description: "",
+    options: [],
+    selectedTags: [],
   };
+
+  componentWillMount() {
+    this.fetchTags();
+  }
 
   onChange = e => this.setState({ [e.target.name]: e.target.value });
 
@@ -18,15 +25,39 @@ class DeckNew extends Component {
 
   onCancel = () => this.props.history.push("/decks");
 
+  onAddTag = (e, { value }) => {
+    this.createTag(value).then(tag => {
+      const option = { text: tag.value, value: tag._id };
+      this.setState({ options: [option, ...this.state.options] });
+    });
+  };
+
+  onChangeTag = (e, { value }) => {
+    this.setState({ selectedTags: value });
+  };
+
+  fetchTags = () => {
+    tagApi.getTags().then(({ data }) => {
+      const options = data.map(tag => ({ text: tag.value, value: tag._id }));
+      this.setState({ options });
+    });
+  };
+
   createDeck = () => {
-    const { title, description } = this.state;
-    api.createDeck({ title, description }).then(response => {
+    const { title, description, selectedTags } = this.state;
+    api.createDeck({ title, description, tags: selectedTags }).then(response => {
       this.props.history.push(`/decks/${response.data._id}`);
     });
   };
 
+  createTag = value => {
+    return tagApi.createTag(value).then(({ data }) => {
+      return data;
+    });
+  };
+
   render() {
-    const { title, description } = this.state;
+    const { title, description, options, selectedTags } = this.state;
 
     return (
       <div className="container mt-4">
@@ -52,6 +83,21 @@ class DeckNew extends Component {
                     name="description"
                     autoHeight
                     placeholder="Add a deck description..."
+                  />
+                </Form.Field>
+                <Form.Field>
+                  <label>Tags</label>
+                  <Dropdown
+                    value={selectedTags}
+                    placeholder="Add tags..."
+                    options={options}
+                    fluid
+                    multiple
+                    search
+                    selection
+                    allowAdditions
+                    onAddItem={this.onAddTag}
+                    onChange={this.onChangeTag}
                   />
                 </Form.Field>
                 <Form.Field className="mt-4">

--- a/src/app/decks/tagActions.js
+++ b/src/app/decks/tagActions.js
@@ -1,0 +1,16 @@
+import axios from "axios";
+import cookie from "js-cookie";
+
+axios.defaults.baseURL = process.env.REACT_APP_SERVER_URL;
+
+export const getTags = () => {
+  const config = { headers: { Authorization: cookie.get("token") } };
+
+  return axios.get("/api/tags", config);
+};
+
+export const createTag = value => {
+  const config = { headers: { Authorization: cookie.get("token") } };
+
+  return axios.post("/api/tags", { value }, config);
+};

--- a/src/components/modals/AddCardModal.js
+++ b/src/components/modals/AddCardModal.js
@@ -9,7 +9,7 @@ class AddItemModal extends Component {
 
   onClose = () => {
     this.props.onClose();
-    this.setState(state => ({ front: "", back: "", numCards: 0 }));
+    this.setState(state => ({ front: "", back: "", notes: "", numCards: 0 }));
   };
 
   onSubmit = () => {

--- a/src/components/modals/EditCardModal.js
+++ b/src/components/modals/EditCardModal.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Button, Form, Modal, TextArea } from "semantic-ui-react";
+import { Button, Form, Modal, TextArea, Input } from "semantic-ui-react";
 
 class EditCardModal extends Component {
   state = { ...this.props.card };
@@ -16,7 +16,7 @@ class EditCardModal extends Component {
   onSubmit = () => this.props.onSubmit(this.state);
 
   render() {
-    const { front, back } = this.state;
+    const { front, back, notes } = this.state;
     const { open, onClose } = this.props;
 
     return (
@@ -44,6 +44,15 @@ class EditCardModal extends Component {
                 onChange={this.onChange}
                 autoHeight
                 placeholder="Add to the card back..."
+              />
+            </Form.Field>
+            <Form.Field>
+              <label htmlFor="notes">Notes</label>
+              <Input
+                onChange={this.onChange}
+                value={notes}
+                name="notes"
+                placeholder="Additional notes..."
               />
             </Form.Field>
           </Form>

--- a/src/components/modals/EditDeckModal.js
+++ b/src/components/modals/EditDeckModal.js
@@ -1,23 +1,61 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { Button, Form, Modal, Input, TextArea } from "semantic-ui-react";
+import { Button, Form, Modal, Input, TextArea, Dropdown } from "semantic-ui-react";
+
+import * as tagApi from "../../app/decks/tagActions";
 
 class EditDeckModal extends Component {
-  state = { ...this.props.deck };
+  state = { deck: this.props.deck };
+
+  componentWillMount() {
+    this.fetchTags();
+  }
 
   componentWillUpdate(nextProps) {
     if (this.props.deck !== nextProps.deck) {
-      this.setState({ ...nextProps.deck });
+      this.setState({ deck: nextProps.deck });
     }
   }
 
-  onChange = e => this.setState({ [e.target.name]: e.target.value });
+  onChange = e => {
+    this.setState({ deck: { ...this.state.deck, [e.target.name]: e.target.value } });
+  };
 
-  onSubmit = () => this.props.onSubmit(this.state);
+  onSubmit = () => this.props.onSubmit(this.state.deck);
+
+  onAddTag = (e, { value }) => {
+    this.createTag(value).then(tag => {
+      const option = { text: tag.value, value: tag._id };
+      this.setState({
+        options: [option, ...this.state.options],
+        deck: { ...this.state.deck, tags: [...this.state.deck.tags, tag._id] },
+      });
+    });
+  };
+
+  onChangeTag = (e, data) => {
+    const { value } = data;
+    const { options } = this.state;
+    const tags = value.filter(el => options.find(tag => tag.value === el));
+    this.setState({ deck: { ...this.state.deck, tags } });
+  };
+
+  fetchTags = () => {
+    tagApi.getTags().then(({ data }) => {
+      const options = data.map(tag => ({ text: tag.value, value: tag._id }));
+      this.setState({ options });
+    });
+  };
+
+  createTag = value => {
+    return tagApi.createTag(value).then(({ data }) => data);
+  };
 
   render() {
-    const { title, description } = this.state;
+    const { deck: { title, description, tags = [] }, options = [] } = this.state;
     const { open, onClose } = this.props;
+
+    const values = tags.map(el => el._id || el);
 
     return (
       <Modal open={open} onClose={onClose} size="tiny" className="position-relative">
@@ -42,6 +80,23 @@ class EditDeckModal extends Component {
                 autoHeight
                 rows={4}
                 placeholder="Add a deck description..."
+              />
+            </Form.Field>
+            <Form.Field>
+              <label>Tags</label>
+              <Dropdown
+                value={values}
+                placeholder="Add tags..."
+                options={options}
+                fluid
+                multiple
+                search
+                selection
+                allowAdditions
+                upward
+                additionPosition="top"
+                onAddItem={this.onAddTag}
+                onChange={this.onChangeTag}
               />
             </Form.Field>
           </Form>


### PR DESCRIPTION
### Description
This PR updates the web app to support adding, editing, and displaying a deck's tags.

### Issue
Related to https://github.com/pensieve-srs/pensieve-api/issues/26

### Screenshots
![screen shot 2018-05-30 at 1 24 57 pm](https://user-images.githubusercontent.com/2153230/40736832-18a9e782-640d-11e8-83cf-2b9a84777952.png)
![screen shot 2018-05-30 at 1 25 03 pm](https://user-images.githubusercontent.com/2153230/40736833-18ba82cc-640d-11e8-93f1-46a8182fd487.png)
