### PR TITLE
Fixed a bug that allowed multiple decks to be created at once

### DIFF
--- a/src/app/decks/new/DeckNew.js
+++ b/src/app/decks/new/DeckNew.js
@@ -54,6 +54,7 @@ class DeckNew extends Component {
     api.createDeck({ title, description, tags: selectedTags }).then(response => {
       this.props.history.push(`/decks/${response.data._id}`);
     });
+    this.setState(state => ({ title: "", description: "",  selectedTags: []}));
   };
 
   createTag = value => {


### PR DESCRIPTION
If a user has a slow connection or fast fingers then clicking "create deck" multiple times would lead to multiple deck being created.

Perhaps this would be more appropriately fixed on the server side of by using the "isLoading" prop to avoid reseting the parameters  in case of a failed validation.

The line used to fix it was `this.setState(state => ({ title: "", description: "",  selectedTags: []}));`